### PR TITLE
changed parameter name to avoid shadowing member variable

### DIFF
--- a/inc/CRC.h
+++ b/inc/CRC.h
@@ -323,8 +323,8 @@ inline CRC::Table<CRCType, CRCWidth> CRC::Parameters<CRCType, CRCWidth>::MakeTab
     @tparam CRCWidth Number of bits in the CRC
 */
 template <typename CRCType, crcpp_uint16 CRCWidth>
-inline CRC::Table<CRCType, CRCWidth>::Table(const Parameters<CRCType, CRCWidth> & parameters) :
-    parameters(parameters)
+inline CRC::Table<CRCType, CRCWidth>::Table(const Parameters<CRCType, CRCWidth> & params) :
+    parameters(params)
 {
     InitTable();
 }
@@ -337,8 +337,8 @@ inline CRC::Table<CRCType, CRCWidth>::Table(const Parameters<CRCType, CRCWidth> 
     @tparam CRCWidth Number of bits in the CRC
 */
 template <typename CRCType, crcpp_uint16 CRCWidth>
-inline CRC::Table<CRCType, CRCWidth>::Table(Parameters<CRCType, CRCWidth> && parameters) :
-    parameters(::std::move(parameters))
+inline CRC::Table<CRCType, CRCWidth>::Table(Parameters<CRCType, CRCWidth> && params) :
+    parameters(::std::move(params))
 {
     InitTable();
 }


### PR DESCRIPTION
gcc-9.1.0 shows some warnings here:

```
In file included from /home/ralf.waldukat/work/se01/itx-psv-ucomm/inc/ErrorControlLayer.h:5,
                 from /home/ralf.waldukat/work/se01/itx-psv-ucomm/src/psv-ucomm.cpp:25:
/home/ralf.waldukat/work/se01/itx-psv-ucomm/inc/CRCpp/inc/CRC.h: In constructor ‘CRC::Table<CRCType, CRCWidth>::Table(const CRC::Parameters<CRCType, CRCWidth>&)’:
/home/ralf.waldukat/work/se01/itx-psv-ucomm/inc/CRCpp/inc/CRC.h:326:93: warning: declaration of ‘parameters’ shadows a member of ‘CRC::Table<CRCType, CRCWidth>’ [-Wshadow]
  326 | inline CRC::Table<CRCType, CRCWidth>::Table(const Parameters<CRCType, CRCWidth> & parameters) :
      |                                                                                             ^
In file included from /home/ralf.waldukat/work/se01/itx-psv-ucomm/inc/ErrorControlLayer.h:5,
                 from /home/ralf.waldukat/work/se01/itx-psv-ucomm/src/psv-ucomm.cpp:25:
/home/ralf.waldukat/work/se01/itx-psv-ucomm/inc/CRCpp/inc/CRC.h:187:39: note: shadowed declaration is here
  187 |         Parameters<CRCType, CRCWidth> parameters; ///< CRC parameters used to construct the table
      |
```

I've changed the parameter name in the initialisier list so the warning is silenced