### PR TITLE
Add version and copyright compile time constants

### DIFF
--- a/inc/CRC.h
+++ b/inc/CRC.h
@@ -138,11 +138,19 @@ namespace CRCPP
 {
 #endif
 
+#ifdef CRCPP_USE_CPP11
 crcpp_constexpr int CRCPP_MAJOR_VERSION = 1;
 crcpp_constexpr int CRCPP_MINOR_VERSION = 2;
 crcpp_constexpr int CRCPP_PATCH_VERSION = 0;
-crcpp_constexpr int CRCPP_TWEAK_VERSION = 0;
+crcpp_constexpr int CRCPP_REVISION_VERSION = 0;
 crcpp_constexpr char CRCPP_COPYRIGHT[] = "Copyright (c) 2022, Daniel Bahr";
+#else
+#define CRCPP_MAJOR_VERSION 1
+#define CRCPP_MINOR_VERSION 2
+#define CRCPP_PATCH_VERSION 0
+#define CRCPP_REVISION_VERSION 0
+#define CRCPP_COPYRIGHT "Copyright (c) 2022, Daniel Bahr"
+#endif
 
 /**
     @brief Static class for computing CRCs.

--- a/inc/CRC.h
+++ b/inc/CRC.h
@@ -138,6 +138,12 @@ namespace CRCPP
 {
 #endif
 
+crcpp_constexpr int CRCPP_MAJOR_VERSION = 1;
+crcpp_constexpr int CRCPP_MINOR_VERSION = 2;
+crcpp_constexpr int CRCPP_PATCH_VERSION = 0;
+crcpp_constexpr int CRCPP_TWEAK_VERSION = 0;
+crcpp_constexpr char CRCPP_COPYRIGHT[] = "Copyright (c) 2022, Daniel Bahr";
+
 /**
     @brief Static class for computing CRCs.
     @note This class supports computation of full and multi-part CRCs, using a bit-by-bit algorithm or a


### PR DESCRIPTION
These can be useful for building information about the library at compile time to include in a parent program's About box.