### PR TITLE
Set CRCPP_USE_CPP11 automatically with conforming C++11 compilers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Define to place all CRC++ code within the ::CRCPP namespace. Not defined by defa
 * `#define CRCPP_BRANCHLESS`<br>
 Define to enable a branchless CRC implementation. The branchless implementation uses a single integer multiplication in the bit-by-bit calculation instead of a small conditional. The branchless implementation may be faster on processor architectures which support single-instruction integer multiplication. Not defined by default.
 * `#define CRCPP_USE_CPP11`
-Define to enables C++11 features (move semantics, constexpr, static_assert, etc.). Not defined by default.
+Define to enables C++11 features (move semantics, constexpr, static_assert, etc.). Enabled by default when a C++11 compiler is detected (`__cplusplus >= 201103L`).
 * `#define CRCPP_INCLUDE_ESOTERIC_CRC_DEFINITIONS`
 Define to include definitions for little-used CRCs. Not defined by default.
 

--- a/inc/CRC.h
+++ b/inc/CRC.h
@@ -1,11 +1,11 @@
 /**
     @file CRC.h
     @author Daniel Bahr
-    @version 1.2.0.0
+    @version 1.2.1.0
     @copyright
     @parblock
         CRC++
-        Copyright (c) 2022, Daniel Bahr
+        Copyright (c) 2022-2025, Daniel Bahr
         All rights reserved.
 
         Redistribution and use in source and binary forms, with or without
@@ -57,6 +57,10 @@
 
 #ifndef CRCPP_CRC_H_
 #define CRCPP_CRC_H_
+
+#if __cplusplus >= 201103L && !defined(CRCPP_USE_CPP11)
+#define CRCPP_USE_CPP11
+#endif
 
 #include <climits>  // Includes CHAR_BIT
 #ifdef CRCPP_USE_CPP11
@@ -141,15 +145,15 @@ namespace CRCPP
 #ifdef CRCPP_USE_CPP11
 crcpp_constexpr int CRCPP_MAJOR_VERSION = 1;
 crcpp_constexpr int CRCPP_MINOR_VERSION = 2;
-crcpp_constexpr int CRCPP_PATCH_VERSION = 0;
+crcpp_constexpr int CRCPP_PATCH_VERSION = 1;
 crcpp_constexpr int CRCPP_REVISION_VERSION = 0;
-crcpp_constexpr char CRCPP_COPYRIGHT[] = "Copyright (c) 2022, Daniel Bahr";
+crcpp_constexpr char CRCPP_COPYRIGHT[] = "Copyright (c) 2022-2025, Daniel Bahr";
 #else
 #define CRCPP_MAJOR_VERSION 1
 #define CRCPP_MINOR_VERSION 2
-#define CRCPP_PATCH_VERSION 0
+#define CRCPP_PATCH_VERSION 1
 #define CRCPP_REVISION_VERSION 0
-#define CRCPP_COPYRIGHT "Copyright (c) 2022, Daniel Bahr"
+#define CRCPP_COPYRIGHT "Copyright (c) 2022-2025, Daniel Bahr"
 #endif
 
 /**

--- a/test/prj/gcc/Makefile
+++ b/test/prj/gcc/Makefile
@@ -18,7 +18,7 @@ $(TARGET): $(OBJ_FILES)
 	$(MKDIR) -p $(BINDIR)
 	$(LINKER) $(LDFLAGS) -o $@ $^
 
-$(OUTDIR)/%.o: $(SRCDIR)/%.cpp
+$(OUTDIR)/%.o: $(SRCDIR)/%.cpp $(INCDIR)/CRC.h
 	$(CXX) $(CXXFLAGS) -c -o $@ $<
 
 $(OUTDIR):

--- a/test/src/main.cpp
+++ b/test/src/main.cpp
@@ -1,11 +1,11 @@
 /**
     @file main.cpp
     @author Daniel Bahr
-    @version 1.2.0.0
+    @version 1.2.1.0
     @copyright
     @parblock
         CRC++
-        Copyright (c) 2022, Daniel Bahr
+        Copyright (c) 2022-2025, Daniel Bahr
         All rights reserved.
 
         Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Also update version to 1.2.1.0 and update copyright.